### PR TITLE
Fix cookie overlay visibility

### DIFF
--- a/about.html
+++ b/about.html
@@ -102,7 +102,7 @@
 </script>
 <footer class="bg-white border-t text-center text-sm text-gray-600 py-10">
 <p>© 2025 Kivo Technologies Ltd. · Built for first-time buyers, dreamers, and doers.</p>
-</footer><div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
+</footer><div class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
 <div class="bg-white rounded-lg shadow-lg max-w-md w-full p-6 text-center">
 <h2 class="text-lg font-semibold mb-4">Cookie Preferences</h2>
 <p class="text-sm text-gray-700 mb-4">We use cookies to enhance your experience. You can manage your preferences below. Read our <a class="text-cyan-700 underline hover:text-cyan-900" href="privacy.html">cookie policy</a>.</p>

--- a/contact.html
+++ b/contact.html
@@ -93,7 +93,7 @@
 </script>
 <footer class="bg-white border-t text-center text-sm text-gray-600 py-10">
 <p>© 2025 Kivo Technologies Ltd. · Built for first-time buyers, dreamers, and doers.</p>
-</footer><div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
+</footer><div class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
 <div class="bg-white rounded-lg shadow-lg max-w-md w-full p-6 text-center">
 <h2 class="text-lg font-semibold mb-4">Cookie Preferences</h2>
 <p class="text-sm text-gray-700 mb-4">We use cookies to enhance your experience. You can manage your preferences below. Read our <a class="text-cyan-700 underline hover:text-cyan-900" href="privacy.html">cookie policy</a>.</p>

--- a/faq.html
+++ b/faq.html
@@ -124,7 +124,7 @@
 </script>
 <footer class="bg-white border-t text-center text-sm text-gray-600 py-10">
 <p>© 2025 Kivo Technologies Ltd. · Built for first-time buyers, dreamers, and doers.</p>
-</footer><div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
+</footer><div class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
 <div class="bg-white rounded-lg shadow-lg max-w-md w-full p-6 text-center">
 <h2 class="text-lg font-semibold mb-4">Cookie Preferences</h2>
 <p class="text-sm text-gray-700 mb-4">We use cookies to enhance your experience. You can manage your preferences below. Read our <a class="text-cyan-700 underline hover:text-cyan-900" href="privacy.html">cookie policy</a>.</p>

--- a/for-advisors.html
+++ b/for-advisors.html
@@ -61,7 +61,7 @@
 </main>
 <footer class="bg-white border-t text-center text-sm text-gray-600 py-10">
 <p>© 2025 Kivo Technologies Ltd. · Built for first-time buyers, dreamers, and doers.</p>
-</footer><div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
+</footer><div class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
 <div class="bg-white rounded-lg shadow-lg max-w-md w-full p-6 text-center">
 <h2 class="text-lg font-semibold mb-4">Cookie Preferences</h2>
 <p class="text-sm text-gray-700 mb-4">We use cookies to enhance your experience. You can manage your preferences below. Read our <a class="text-cyan-700 underline hover:text-cyan-900" href="privacy.html">cookie policy</a>.</p>

--- a/how-it-works.html
+++ b/how-it-works.html
@@ -116,7 +116,7 @@
 </script>
 <footer class="bg-white border-t text-center text-sm text-gray-600 py-10">
 <p>© 2025 Kivo Technologies Ltd. · Built for first-time buyers, dreamers, and doers.</p>
-</footer><div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
+</footer><div class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
 <div class="bg-white rounded-lg shadow-lg max-w-md w-full p-6 text-center">
 <h2 class="text-lg font-semibold mb-4">Cookie Preferences</h2>
 <p class="text-sm text-gray-700 mb-4">We use cookies to enhance your experience. You can manage your preferences below. Read our <a class="text-cyan-700 underline hover:text-cyan-900" href="privacy.html">cookie policy</a>.</p>

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
   <footer class="bg-white border-t text-center text-sm text-gray-600 py-10">
     <p>© 2025 Kivo Technologies Ltd. · Built for first-time buyers, dreamers, and doers.</p>
   </footer>
-<div id="cookiePreferencesOverlay" class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn">
+<div id="cookiePreferencesOverlay" class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn">
   <div class="bg-white rounded-lg shadow-lg max-w-md w-full p-6 text-center">
     <h2 class="text-lg font-semibold mb-4">Cookie Preferences</h2>
     <p class="text-sm text-gray-700 mb-4">We use cookies to enhance your experience. You can manage your preferences below. Read our <a href='privacy.html' class='text-cyan-700 underline hover:text-cyan-900'>cookie policy</a>.</p>

--- a/kivo-check.html
+++ b/kivo-check.html
@@ -210,7 +210,7 @@ nextBtn.addEventListener("click", () => {
 </script>
 <footer class="bg-white border-t text-center text-sm text-gray-600 py-10">
 <p>© 2025 Kivo Technologies Ltd. · Built for first-time buyers, dreamers, and doers.</p>
-</footer><div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
+</footer><div class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
 <div class="bg-white rounded-lg shadow-lg max-w-md w-full p-6 text-center">
 <h2 class="text-lg font-semibold mb-4">Cookie Preferences</h2>
 <p class="text-sm text-gray-700 mb-4">We use cookies to enhance your experience. You can manage your preferences below. Read our <a class="text-cyan-700 underline hover:text-cyan-900" href="privacy.html">cookie policy</a>.</p>

--- a/kivo-score.html
+++ b/kivo-score.html
@@ -150,7 +150,7 @@
 </script>
 <footer class="bg-white border-t text-center text-sm text-gray-600 py-10">
 <p>© 2025 Kivo Technologies Ltd. · Built for first-time buyers, dreamers, and doers.</p>
-</footer><div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
+</footer><div class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
 <div class="bg-white rounded-lg shadow-lg max-w-md w-full p-6 text-center">
 <h2 class="text-lg font-semibold mb-4">Cookie Preferences</h2>
 <p class="text-sm text-gray-700 mb-4">We use cookies to enhance your experience. You can manage your preferences below. Read our <a class="text-cyan-700 underline hover:text-cyan-900" href="privacy.html">cookie policy</a>.</p>

--- a/learn.html
+++ b/learn.html
@@ -61,7 +61,7 @@
 </main>
 <footer class="bg-white border-t text-center text-sm text-gray-600 py-10">
 <p>© 2025 Kivo Technologies Ltd. · Built for first-time buyers, dreamers, and doers.</p>
-</footer><div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
+</footer><div class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
 <div class="bg-white rounded-lg shadow-lg max-w-md w-full p-6 text-center">
 <h2 class="text-lg font-semibold mb-4">Cookie Preferences</h2>
 <p class="text-sm text-gray-700 mb-4">We use cookies to enhance your experience. You can manage your preferences below. Read our <a class="text-cyan-700 underline hover:text-cyan-900" href="privacy.html">cookie policy</a>.</p>

--- a/partners.html
+++ b/partners.html
@@ -61,7 +61,7 @@
 </main>
 <footer class="bg-white border-t text-center text-sm text-gray-600 py-10">
 <p>© 2025 Kivo Technologies Ltd. · Built for first-time buyers, dreamers, and doers.</p>
-</footer><div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
+</footer><div class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
 <div class="bg-white rounded-lg shadow-lg max-w-md w-full p-6 text-center">
 <h2 class="text-lg font-semibold mb-4">Cookie Preferences</h2>
 <p class="text-sm text-gray-700 mb-4">We use cookies to enhance your experience. You can manage your preferences below. Read our <a class="text-cyan-700 underline hover:text-cyan-900" href="privacy.html">cookie policy</a>.</p>

--- a/privacy.html
+++ b/privacy.html
@@ -162,7 +162,7 @@
 </script>
 <footer class="bg-white border-t text-center text-sm text-gray-600 py-10">
 <p>© 2025 Kivo Technologies Ltd. · Built for first-time buyers, dreamers, and doers.</p>
-</footer><div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
+</footer><div class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
 <div class="bg-white rounded-lg shadow-lg max-w-md w-full p-6 text-center">
 <h2 class="text-lg font-semibold mb-4">Cookie Preferences</h2>
 <p class="text-sm text-gray-700 mb-4">We use cookies to enhance your experience. You can manage your preferences below. Read our <a class="text-cyan-700 underline hover:text-cyan-900" href="privacy.html">cookie policy</a>.</p>

--- a/security.html
+++ b/security.html
@@ -61,7 +61,7 @@
 </main>
 <footer class="bg-white border-t text-center text-sm text-gray-600 py-10">
 <p>© 2025 Kivo Technologies Ltd. · Built for first-time buyers, dreamers, and doers.</p>
-</footer><div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
+</footer><div class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
 <div class="bg-white rounded-lg shadow-lg max-w-md w-full p-6 text-center">
 <h2 class="text-lg font-semibold mb-4">Cookie Preferences</h2>
 <p class="text-sm text-gray-700 mb-4">We use cookies to enhance your experience. You can manage your preferences below. Read our <a class="text-cyan-700 underline hover:text-cyan-900" href="privacy.html">cookie policy</a>.</p>

--- a/stories.html
+++ b/stories.html
@@ -61,7 +61,7 @@
 </main>
 <footer class="bg-white border-t text-center text-sm text-gray-600 py-10">
 <p>© 2025 Kivo Technologies Ltd. · Built for first-time buyers, dreamers, and doers.</p>
-</footer><div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
+</footer><div class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
 <div class="bg-white rounded-lg shadow-lg max-w-md w-full p-6 text-center">
 <h2 class="text-lg font-semibold mb-4">Cookie Preferences</h2>
 <p class="text-sm text-gray-700 mb-4">We use cookies to enhance your experience. You can manage your preferences below. Read our <a class="text-cyan-700 underline hover:text-cyan-900" href="privacy.html">cookie policy</a>.</p>

--- a/thankyou.html
+++ b/thankyou.html
@@ -62,7 +62,7 @@
 </main>
 <footer class="bg-white border-t text-center text-sm text-gray-600 py-10">
 <p>© 2025 Kivo Technologies Ltd. · Built for first-time buyers, dreamers, and doers.</p>
-</footer><div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
+</footer><div class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
 <div class="bg-white rounded-lg shadow-lg max-w-md w-full p-6 text-center">
 <h2 class="text-lg font-semibold mb-4">Cookie Preferences</h2>
 <p class="text-sm text-gray-700 mb-4">We use cookies to enhance your experience. You can manage your preferences below. Read our <a class="text-cyan-700 underline hover:text-cyan-900" href="privacy.html">cookie policy</a>.</p>

--- a/tools.html
+++ b/tools.html
@@ -61,7 +61,7 @@
 </main>
 <footer class="bg-white border-t text-center text-sm text-gray-600 py-10">
 <p>© 2025 Kivo Technologies Ltd. · Built for first-time buyers, dreamers, and doers.</p>
-</footer><div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
+</footer><div class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center transition-opacity duration-300 opacity-0 animate-fadeIn" id="cookiePreferencesOverlay">
 <div class="bg-white rounded-lg shadow-lg max-w-md w-full p-6 text-center">
 <h2 class="text-lg font-semibold mb-4">Cookie Preferences</h2>
 <p class="text-sm text-gray-700 mb-4">We use cookies to enhance your experience. You can manage your preferences below. Read our <a class="text-cyan-700 underline hover:text-cyan-900" href="privacy.html">cookie policy</a>.</p>


### PR DESCRIPTION
## Summary
- hide the cookie preferences overlay by default across the site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685147bce4188322bfdfb17402eb5b12